### PR TITLE
Add float option

### DIFF
--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -60,6 +60,7 @@ import (
 var (
 	name       = flag.String("name", "Foo", "the name of the struct")
 	pkg        = flag.String("pkg", "main", "the name of the package for the generated code")
+	floats     = flag.Bool("floats", false, "whether to always use float64 for JSON numbers")
 	inputName  = flag.String("input", "", "the name of the input file containing JSON (if input not provided via STDIN)")
 	outputName = flag.String("o", "", "the name of the file to write the output to (outputs to STDOUT by default)")
 )
@@ -285,7 +286,7 @@ func typeForValue(value interface{}) string {
 func disambiguateFloatInt(value interface{}) string {
 	const epsilon = .0001
 	vfloat := value.(float64)
-	if math.Abs(vfloat-math.Floor(vfloat+epsilon)) < epsilon {
+	if !*floats && math.Abs(vfloat-math.Floor(vfloat+epsilon)) < epsilon {
 		var tmp int = 1
 		return reflect.TypeOf(tmp).Name()
 	}

--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -287,7 +287,7 @@ func disambiguateFloatInt(value interface{}) string {
 	const epsilon = .0001
 	vfloat := value.(float64)
 	if !*floats && math.Abs(vfloat-math.Floor(vfloat+epsilon)) < epsilon {
-		var tmp int = 1
+		var tmp int
 		return reflect.TypeOf(tmp).Name()
 	}
 	return reflect.TypeOf(value).Name()

--- a/json-to-struct_test.go
+++ b/json-to-struct_test.go
@@ -40,6 +40,31 @@ func TestInvalidFieldChars(t *testing.T) {
 	}
 }
 
+// TestDisambiguateFloatInt tests that disambiguateFloatInt correctly
+// converts JSON numbers to the desired types.
+func TestDisambiguateFloatInt(t *testing.T) {
+	examples := []struct {
+		FloatsOnly bool
+		In         interface{}
+		Out        string
+	}{
+		{FloatsOnly: false, In: 2.2, Out: "float64"},
+		{FloatsOnly: false, In: 2.0, Out: "int"},
+		{FloatsOnly: false, In: float64(2), Out: "int"},
+		{FloatsOnly: true, In: 2.2, Out: "float64"},
+		{FloatsOnly: true, In: 2.0, Out: "float64"},
+		{FloatsOnly: true, In: float64(2), Out: "float64"},
+	}
+
+	for i, ex := range examples {
+		*floats = ex.FloatsOnly
+		if actual := disambiguateFloatInt(ex.In); actual != ex.Out {
+			t.Errorf("[Example %d] got %q, but expected %q", i+1, actual, ex.Out)
+		}
+	}
+	*floats = false
+}
+
 // Test example document
 func TestExample(t *testing.T) {
 	i, err := os.Open("example.json")


### PR DESCRIPTION
Addresses #21.

Add support for enforcing all `JSON` numbers are converted to `float64` typed values.
