### PR TITLE
Strip leading underscores from JSON field names

### DIFF
--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -241,6 +241,11 @@ func lintFieldName(name string) string {
 	if name == "_" {
 		return name
 	}
+
+	if len(name) > 0 && name[0] == '_' {
+		name = name[1:]
+	}
+
 	allLower := true
 	for _, r := range name {
 		if !unicode.IsLower(r) {

--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -242,7 +242,7 @@ func lintFieldName(name string) string {
 		return name
 	}
 
-	if len(name) > 0 && name[0] == '_' {
+	for len(name) > 0 && name[0] == '_' {
 		name = name[1:]
 	}
 

--- a/json-to-struct_test.go
+++ b/json-to-struct_test.go
@@ -75,6 +75,7 @@ func TestFmtFieldName(t *testing.T) {
 		{in: "foobar", out: "Foobar"},
 		{in: "url_sample", out: "URLSample"},
 		{in: "_id", out: "ID"},
+		{in: "__id", out: "ID"},
 	}
 
 	for _, testCase := range testCases {

--- a/json-to-struct_test.go
+++ b/json-to-struct_test.go
@@ -74,6 +74,7 @@ func TestFmtFieldName(t *testing.T) {
 		{in: "foo_url", out: "FooURL"},
 		{in: "foobar", out: "Foobar"},
 		{in: "url_sample", out: "URLSample"},
+		{in: "_id", out: "ID"},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Turns {"_id": "..."} into struct{ID string}. Encountered in the Twitch.tv API.