### PR TITLE
Stringify first char of key name, should it be a int.

### DIFF
--- a/example.json
+++ b/example.json
@@ -27,5 +27,6 @@
   "following": 88,
   "created_at": "2008-03-27T15:49:13Z",
   "updated_at": "2013-09-05T00:03:43Z",
-  "public_gists": 44
+  "public_gists": 44,
+  "1number_key": 1
 }

--- a/expected_output_test.go
+++ b/expected_output_test.go
@@ -1,6 +1,7 @@
 package json2struct
 
 type User struct {
+	OneNumberKey      int         `json:"1number_key"`
 	AvatarURL         string      `json:"avatar_url"`
 	Bio               interface{} `json:"bio"`
 	Blog              string      `json:"blog"`

--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -104,6 +104,7 @@ import (
 	"math"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -143,6 +144,19 @@ var commonInitialisms = map[string]bool{
 	"UTF8":  true,
 	"VM":    true,
 	"XML":   true,
+}
+
+var intToWordMap = []string{
+	"zero",
+	"one",
+	"two",
+	"three",
+	"four",
+	"five",
+	"six",
+	"seven",
+	"eight",
+	"nine",
 }
 
 // Given a JSON string representation of an object and a name structName,
@@ -207,7 +221,7 @@ func generateTypes(obj map[string]interface{}, depth int) string {
 			valueType = generateTypes(value, depth+1) + "}"
 		}
 
-		fieldName := fmtFieldName(key)
+		fieldName := fmtFieldName(stringifyFirstChar(key))
 		structure += fmt.Sprintf("\n%s %s `json:\"%s\"`",
 			fieldName,
 			valueType,
@@ -341,4 +355,17 @@ func disambiguateFloatInt(value interface{}) string {
 		return reflect.TypeOf(tmp).Name()
 	}
 	return reflect.TypeOf(value).Name()
+}
+
+// convert first character ints to strings
+func stringifyFirstChar(str string) string {
+	first := str[:1]
+
+	i, err := strconv.ParseInt(first, 10, 8)
+
+	if err != nil {
+		return str
+	}
+
+	return intToWordMap[i] + "_" + str[1:]
 }


### PR DESCRIPTION
This was reported to me as an error by someone using http://json2struct.herokuapp.com/. Specific example is parsing http status code information, e.g.:

```javascript
{
   "200": 1000,
   "3xx": 10,
    // ... etc ...
}
```

Expected results with this change would be:

```go
type Foo struct {
    Two00   int `json:"200"`
    ThreeXx int `json:"3xx"`
    // ... etc ...
}
```