### PR TITLE
Fix substructure output format

### DIFF
--- a/gojson/gojson.go
+++ b/gojson/gojson.go
@@ -59,7 +59,7 @@ var (
 	pkg         = flag.String("pkg", "main", "the name of the package for the generated code")
 	inputName   = flag.String("input", "", "the name of the input file containing JSON (if input not provided via STDIN)")
 	outputName  = flag.String("o", "", "the name of the file to write the output to (outputs to STDOUT by default)")
-	format      = flag.String("fmt", "json", "the format of the input data (json or yaml, defaults to json)")
+	fmtType     = flag.String("fmt", "json", "the format of the input data (json or yaml, defaults to json)")
 	tags        = flag.String("tags", "fmt", "comma seperated list of the tags to put on the struct, default is the same as fmt")
 	forceFloats = flag.Bool("forcefloats", false, "[experimental] force float64 type for integral values")
 	subStruct   = flag.Bool("subStruct", false, "create types for sub-structs (default is false)")
@@ -68,7 +68,7 @@ var (
 func main() {
 	flag.Parse()
 
-	if *format != "json" && *format != "yaml" {
+	if *fmtType != "json" && *fmtType != "yaml" {
 		flag.Usage()
 		fmt.Fprintln(os.Stderr, "fmt must be json or yaml")
 		os.Exit(1)
@@ -76,7 +76,7 @@ func main() {
 
 	tagList := make([]string, 0)
 	if tags == nil || *tags == "" || *tags == "fmt" {
-		tagList = append(tagList, *format)
+		tagList = append(tagList, *fmtType)
 	} else {
 		tagList = strings.Split(*tags, ",")
 	}
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	var parser Parser
-	switch *format {
+	switch *fmtType {
 	case "json":
 		parser = ParseJson
 	case "yaml":

--- a/gojson/gojson.go
+++ b/gojson/gojson.go
@@ -45,6 +45,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/format"
 	"io"
 	"io/ioutil"
 	"log"
@@ -111,12 +112,18 @@ func main() {
 		os.Exit(1)
 	} else {
 		if *outputName != "" {
-			err := ioutil.WriteFile(*outputName, output, 0644)
-			if err != nil {
-				log.Fatalf("writing output: %s", err)
+			for i, out := range output {
+				formatted, err := format.Source([]byte(out))
+				if err != nil {
+					log.Fatalf("error formatting: %s", err)
+					os.Exit(1)
+				}
+				if err = ioutil.WriteFile(fmt.Sprintf("%02d_%s", i, *outputName), formatted, 0644); err != nil {
+					log.Fatalf("writing output: %s", err)
+				}
 			}
 		} else {
-			fmt.Print(string(output))
+			fmt.Print(strings.Join(output, "\n\n"))
 		}
 	}
 

--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -100,7 +100,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"go/format"
 	"io"
 	"math"
 	"reflect"
@@ -199,7 +198,7 @@ func readFile(input io.Reader) ([]byte, error) {
 
 // Given a JSON string representation of an object and a name structName,
 // attemp to generate a struct definition
-func Generate(input io.Reader, parser Parser, structName, pkgName string, tags []string, subStruct bool) ([]byte, error) {
+func Generate(input io.Reader, parser Parser, structName, pkgName string, tags []string, subStruct bool) ([]string, error) {
 	var subStructMap map[string]string = nil
 	if subStruct {
 		subStructMap = make(map[string]string)
@@ -222,11 +221,7 @@ func Generate(input io.Reader, parser Parser, structName, pkgName string, tags [
 			pkgName,
 			structName,
 			typeForValue(iresult, structName, tags, subStructMap))
-		formatted, err := format.Source([]byte(src))
-		if err != nil {
-			err = fmt.Errorf("error formatting: %s, was formatting\n%s", err, src)
-		}
-		return formatted, err
+		return []string{src}, nil
 	default:
 		return nil, fmt.Errorf("unexpected type: %T", iresult)
 	}
@@ -242,16 +237,11 @@ func Generate(input io.Reader, parser Parser, structName, pkgName string, tags [
 	}
 
 	sort.Strings(keys)
-
+	srces := []string{src}
 	for _, k := range keys {
-		src = fmt.Sprintf("%v\n\ntype %v %v", src, subStructMap[k], k)
+		srces = append(srces, fmt.Sprintf("package %s\n\ntype %v %v", pkgName, subStructMap[k], k))
 	}
-
-	formatted, err := format.Source([]byte(src))
-	if err != nil {
-		err = fmt.Errorf("error formatting: %s, was formatting\n%s", err, src)
-	}
-	return formatted, err
+	return srces, err
 }
 
 func convertKeysToStrings(obj map[interface{}]interface{}) map[string]interface{} {

--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -288,8 +288,7 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 						if val, ok := subStructMap[sub]; ok {
 							subName = val
 						} else {
-							subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
-
+							subName = FmtFieldName(key)
 							subStructMap[sub] = subName
 						}
 					}
@@ -305,8 +304,7 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 				if val, ok := subStructMap[sub]; ok {
 					subName = val
 				} else {
-					subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
-
+					subName = FmtFieldName(key)
 					subStructMap[sub] = subName
 				}
 			}
@@ -319,8 +317,7 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 				if val, ok := subStructMap[sub]; ok {
 					subName = val
 				} else {
-					subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
-
+					subName = FmtFieldName(key)
 					subStructMap[sub] = subName
 				}
 			}


### PR DESCRIPTION
## Changes
* Change the variable name from format to fmtType, because of conflict with go/format package.
* I want to check same structure, so I divide an output file each structes.
* Usually, substructure name and field name are equal. Therefore I change its name to field name.