### PR TITLE
Add Go 1.9, race detector, and gofmt to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+os:
+    - linux
+    - osx
+
 go:
     - 1.5
     - 1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,18 @@ go:
     - 1.6
     - 1.7
     - 1.8
+    - 1.9
     - tip
+
+before_script:
+  - gofmt -w .
+
+  # If `go generate` or `gofmt` yielded any changes,
+  # this will fail with an error message like "too many arguments"
+  # or "M: binary operator expected"
+  - git add .
+  - git diff-index --cached --exit-code HEAD
+
+script:
+    - go test -race -v -timeout 120s ./...
 

--- a/vendor/gopkg.in/yaml.v2/emitterc.go
+++ b/vendor/gopkg.in/yaml.v2/emitterc.go
@@ -995,9 +995,9 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		space_break    = false
 
 		preceded_by_whitespace = false
-		followed_by_whitespace  = false
-		previous_space          = false
-		previous_break          = false
+		followed_by_whitespace = false
+		previous_space         = false
+		previous_break         = false
 	)
 
 	emitter.scalar_data.value = value

--- a/vendor/gopkg.in/yaml.v2/example_embedded_test.go
+++ b/vendor/gopkg.in/yaml.v2/example_embedded_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-        "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // An example showing how to unmarshal embedded
@@ -17,8 +17,8 @@ type StructA struct {
 type StructB struct {
 	// Embedded structs are not treated as embedded in YAML by default. To do that,
 	// add the ",inline" annotation below
-	StructA   `yaml:",inline"`
-	B string `yaml:"b"`
+	StructA `yaml:",inline"`
+	B       string `yaml:"b"`
 }
 
 var data = `
@@ -33,9 +33,9 @@ func ExampleUnmarshal_embedded() {
 	if err != nil {
 		log.Fatal("cannot unmarshal data: %v", err)
 	}
-        fmt.Println(b.A)
-        fmt.Println(b.B)
-        // Output:
-        // a string from struct A
-        // a string from struct B
+	fmt.Println(b.A)
+	fmt.Println(b.B)
+	// Output:
+	// a string from struct A
+	// a string from struct B
 }


### PR DESCRIPTION
Add Go 1.9 to build matrix.

Also enable the race detector, and a gofmt check to the Travis CI build