### PR TITLE
Changes how whole numbers are handled in YAML

### DIFF
--- a/examples/expected_numbers.go.out
+++ b/examples/expected_numbers.go.out
@@ -1,0 +1,7 @@
+package gojson
+
+type Stats struct {
+	Count  int     `yaml:"count"`
+	Mean   float64 `yaml:"mean"`
+	Median float64 `yaml:"median"`
+}

--- a/examples/numbers.yaml
+++ b/examples/numbers.yaml
@@ -1,0 +1,3 @@
+count: 100
+mean: 22.5
+median: 20.0

--- a/gojson/gojson.go
+++ b/gojson/gojson.go
@@ -98,15 +98,17 @@ func main() {
 		input = f
 	}
 
+	var convertFloats bool
 	var parser Parser
 	switch *format {
 	case "json":
 		parser = ParseJson
+		convertFloats = true
 	case "yaml":
 		parser = ParseYaml
 	}
 
-	if output, err := Generate(input, parser, *name, *pkg, tagList, *subStruct); err != nil {
+	if output, err := Generate(input, parser, *name, *pkg, tagList, *subStruct, convertFloats); err != nil {
 		fmt.Fprintln(os.Stderr, "error parsing", err)
 		os.Exit(1)
 	} else {

--- a/json-to-array_test.go
+++ b/json-to-array_test.go
@@ -26,7 +26,7 @@ func TestExampleArray(t *testing.T) {
 		t.Fatalf("error reading example_array.go: %s", err)
 	}
 
-	actual, err := Generate(i, ParseJson, "Users", "gojson", []string{"json"}, false)
+	actual, err := Generate(i, ParseJson, "Users", "gojson", []string{"json"}, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### Summary

This changes `gojson`’s behavior with YAML output so that it doesn’t try to infer whether YAML integers are floats.

Also reformatted a docstring comment to appease the linter gods.

#### Motivation

Since YAML’s spec includes [unambiguous tagging for integers and floats](http://yaml.org/spec/1.2/spec.html#id2761509), we don’t need to use `disambiguateFloatInt` to turn whole numbers from floats to integers.

#### Testing

Added tests for this behavior as well!

Hope this is helpful @ChimeraCoder – it unfortunately doesn’t really solve the problem of #44 :(