### PR TITLE
Ignore tests in vendor directory for older Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,18 @@ os:
     - osx
 
 go:
-    - 1.5
-    - 1.6
     - 1.7
     - 1.8
     - 1.9
     - tip
+
+
+matrix:
+    include:
+        - os: linux
+          go: 1.5
+        - os: linux
+          go: 1.6
 
 before_script:
   - gofmt -w .

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ before_script:
   - git diff-index --cached --exit-code HEAD
 
 script:
-    - go test -race -v -timeout 120s ./...
+  - if [ "$TRAVIS_GO_VERSION" == "1.5" ] || [ "$TRAVIS_GO_VERSION" == "1.6" ] || [ "$TRAVIS_GO_VERSION" == "1.7" ] || [ "$TRAVIS_GO_VERSION" == "1.8" ]; then go list ./... | grep -v vendor | xargs go test -race -v -timeout 120s; else go test -race -v -timeout 120s ./...; fi
 

--- a/json-to-array_test.go
+++ b/json-to-array_test.go
@@ -11,13 +11,13 @@ import (
 func TestExampleArray(t *testing.T) {
 	i, err := os.Open(filepath.Join("examples", "example_array.json"))
 	if err != nil {
-		t.Fatal("error opening example.json: %s", err)
+		t.Fatalf("error opening example.json: %s", err)
 	}
 	defer i.Close()
 
 	expectedf, err := os.Open(filepath.Join("examples", "example_array.go.out"))
 	if err != nil {
-		t.Fatal("error opening example_array.go: %s", err)
+		t.Fatalf("error opening example_array.go: %s", err)
 	}
 	defer expectedf.Close()
 


### PR DESCRIPTION
`./...` matches the `vendor/` directory in Go, which causes spurious test failures in the yaml package we use.

This also drops tests for 1.5 and 1.6 on OS X, because the Travis OS X image for those is not working. 1.5 and 1.6 are still tested on Linux and Windows.