### PR TITLE
Drop tests for Go 1.5 and 1.6 on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,18 @@ os:
     - osx
 
 go:
-    - 1.5
-    - 1.6
     - 1.7
     - 1.8
     - 1.9
     - tip
+
+
+matrix:
+    include:
+        - os: linux
+          go: 1.5
+        - os: linux
+          go: 1.6
 
 before_script:
   - gofmt -w .


### PR DESCRIPTION
The Travis image for these versions on OS X is buggy. We will still test 1.5 and 1.6 on Linux, but not OS X.