### PR TITLE
use element's json path (without path separator) as struct name

### DIFF
--- a/gojson/gojson.go
+++ b/gojson/gojson.go
@@ -51,7 +51,7 @@ import (
 	"os"
 	"strings"
 
-	. "github.com/ChimeraCoder/gojson"
+	. "github.com/lobatt/gojson"
 )
 
 var (

--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -297,7 +297,8 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 						if val, ok := subStructMap[sub]; ok {
 							subName = val
 						} else {
-							subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
+							//subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
+							subName = strings.Title(key)
 
 							subStructMap[sub] = subName
 						}
@@ -314,7 +315,8 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 				if val, ok := subStructMap[sub]; ok {
 					subName = val
 				} else {
-					subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
+					//subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
+					subName = strings.Title(key)
 
 					subStructMap[sub] = subName
 				}
@@ -328,7 +330,8 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 				if val, ok := subStructMap[sub]; ok {
 					subName = val
 				} else {
-					subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
+					//subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
+					subName = strings.Title(key)
 
 					subStructMap[sub] = subName
 				}

--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -298,7 +298,7 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 							subName = val
 						} else {
 							//subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
-							subName = strings.Title(key)
+							subName = structName + strings.Title(key)
 
 							subStructMap[sub] = subName
 						}
@@ -316,7 +316,7 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 					subName = val
 				} else {
 					//subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
-					subName = strings.Title(key)
+					subName = structName + strings.Title(key)
 
 					subStructMap[sub] = subName
 				}
@@ -331,7 +331,7 @@ func generateTypes(obj map[string]interface{}, structName string, tags []string,
 					subName = val
 				} else {
 					//subName = fmt.Sprintf("%v_sub%v", structName, len(subStructMap)+1)
-					subName = strings.Title(key)
+					subName = structName + strings.Title(key)
 
 					subStructMap[sub] = subName
 				}


### PR DESCRIPTION
As a proposal to #14, I think this will generate better struct names while avoiding the issue of different structs with the same name overriding each other.

Let me know what you think :)