### PR TITLE
Support time.Time types

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ type Repository struct {
 	CompareURL       string      `json:"compare_url"`
 	ContentsURL      string      `json:"contents_url"`
 	ContributorsURL  string      `json:"contributors_url"`
-	CreatedAt        string      `json:"created_at"`
+	CreatedAt        time.Time   `json:"created_at"`
 	DefaultBranch    string      `json:"default_branch"`
 	Description      string      `json:"description"`
 	DownloadsURL     string      `json:"downloads_url"`
@@ -80,23 +80,23 @@ type Repository struct {
 		Type              string  `json:"type"`
 		URL               string  `json:"url"`
 	} `json:"owner"`
-	Private         bool    `json:"private"`
-	PullsURL        string  `json:"pulls_url"`
-	PushedAt        string  `json:"pushed_at"`
-	Size            float64 `json:"size"`
-	SshURL          string  `json:"ssh_url"`
-	StargazersURL   string  `json:"stargazers_url"`
-	StatusesURL     string  `json:"statuses_url"`
-	SubscribersURL  string  `json:"subscribers_url"`
-	SubscriptionURL string  `json:"subscription_url"`
-	SvnURL          string  `json:"svn_url"`
-	TagsURL         string  `json:"tags_url"`
-	TeamsURL        string  `json:"teams_url"`
-	TreesURL        string  `json:"trees_url"`
-	UpdatedAt       string  `json:"updated_at"`
-	URL             string  `json:"url"`
-	Watchers        float64 `json:"watchers"`
-	WatchersCount   float64 `json:"watchers_count"`
+	Private         bool       `json:"private"`
+	PullsURL        string     `json:"pulls_url"`
+	PushedAt        string     `json:"pushed_at"`
+	Size            float64    `json:"size"`
+	SshURL          string     `json:"ssh_url"`
+	StargazersURL   string     `json:"stargazers_url"`
+	StatusesURL     string     `json:"statuses_url"`
+	SubscribersURL  string     `json:"subscribers_url"`
+	SubscriptionURL string     `json:"subscription_url"`
+	SvnURL          string     `json:"svn_url"`
+	TagsURL         string     `json:"tags_url"`
+	TeamsURL        string     `json:"teams_url"`
+	TreesURL        string     `json:"trees_url"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	URL             string     `json:"url"`
+	Watchers        float64    `json:"watchers"`
+	WatchersCount   float64    `json:"watchers_count"`
 }
 ```
 

--- a/examples/example_array.go.out
+++ b/examples/example_array.go.out
@@ -5,7 +5,7 @@ type Users []struct {
 	Bio               interface{} `json:"bio"`
 	Blog              string      `json:"blog"`
 	Company           interface{} `json:"company"`
-	CreatedAt         string      `json:"created_at"`
+	CreatedAt         time.Time   `json:"created_at"`
 	Email             interface{} `json:"email"`
 	EventsURL         string      `json:"events_url"`
 	Followers         int64       `json:"followers"`
@@ -29,6 +29,6 @@ type Users []struct {
 	StarredURL        string      `json:"starred_url"`
 	SubscriptionsURL  string      `json:"subscriptions_url"`
 	Type              string      `json:"type"`
-	UpdatedAt         string      `json:"updated_at"`
+	UpdatedAt         time.Time   `json:"updated_at"`
 	URL               string      `json:"url"`
 }

--- a/examples/expected_output_array_test.go.out
+++ b/examples/expected_output_array_test.go.out
@@ -10,7 +10,7 @@ type Users []struct {
 	Bio               interface{} `json:"bio"`
 	Blog              string      `json:"blog"`
 	Company           string      `json:"company"`
-	CreatedAt         string      `json:"created_at"`
+	CreatedAt         time.Time   `json:"created_at"`
 	Email             string      `json:"email"`
 	EventsURL         string      `json:"events_url"`
 	Followers         int64       `json:"followers"`
@@ -33,6 +33,6 @@ type Users []struct {
 	StarredURL        string      `json:"starred_url"`
 	SubscriptionsURL  string      `json:"subscriptions_url"`
 	Type              string      `json:"type"`
-	UpdatedAt         string      `json:"updated_at"`
+	UpdatedAt         time.Time   `json:"updated_at"`
 	URL               string      `json:"url"`
 }

--- a/examples/expected_output_test.go.out
+++ b/examples/expected_output_test.go.out
@@ -6,7 +6,7 @@ type User struct {
 	Bio               interface{} `json:"bio"`
 	Blog              string      `json:"blog"`
 	Company           string      `json:"company"`
-	CreatedAt         string      `json:"created_at"`
+	CreatedAt         time.Time   `json:"created_at"`
 	Email             string      `json:"email"`
 	EventsURL         string      `json:"events_url"`
 	Followers         int64       `json:"followers"`
@@ -29,6 +29,6 @@ type User struct {
 	StarredURL        string      `json:"starred_url"`
 	SubscriptionsURL  string      `json:"subscriptions_url"`
 	Type              string      `json:"type"`
-	UpdatedAt         string      `json:"updated_at"`
+	UpdatedAt         time.Time   `json:"updated_at"`
 	URL               string      `json:"url"`
 }

--- a/gojson/gojson.go
+++ b/gojson/gojson.go
@@ -13,7 +13,7 @@
 // 		Bio               interface{} `json:"bio"`
 // 		Blog              string      `json:"blog"`
 // 		Company           string      `json:"company"`
-// 		CreatedAt         string      `json:"created_at"`
+// 		CreatedAt         time.Time   `json:"created_at"`
 // 		Email             string      `json:"email"`
 // 		EventsURL         string      `json:"events_url"`
 // 		Followers         float64     `json:"followers"`
@@ -36,7 +36,7 @@
 // 		StarredURL        string      `json:"starred_url"`
 // 		SubscriptionsURL  string      `json:"subscriptions_url"`
 // 		Type              string      `json:"type"`
-// 		UpdatedAt         string      `json:"updated_at"`
+// 		UpdatedAt         time.Time   `json:"updated_at"`
 // 		URL               string      `json:"url"`
 // 	}
 

--- a/json-to-struct.go
+++ b/json-to-struct.go
@@ -20,7 +20,7 @@
 //     	CompareURL       string      `json:"compare_url"`
 //     	ContentsURL      string      `json:"contents_url"`
 //     	ContributorsURL  string      `json:"contributors_url"`
-//     	CreatedAt        string      `json:"created_at"`
+//     	CreatedAt        time.Time   `json:"created_at"`
 //     	DefaultBranch    string      `json:"default_branch"`
 //     	Description      string      `json:"description"`
 //     	DownloadsURL     string      `json:"downloads_url"`
@@ -76,23 +76,23 @@
 //         	Type              string  `json:"type"`
 //         	URL               string  `json:"url"`
 //     } `	json:"owner"`
-//     	Private         bool    `json:"private"`
-//     	PullsURL        string  `json:"pulls_url"`
-//     	PushedAt        string  `json:"pushed_at"`
-//     	Size            float64 `json:"size"`
-//     	SshURL          string  `json:"ssh_url"`
-//     	StargazersURL   string  `json:"stargazers_url"`
-//     	StatusesURL     string  `json:"statuses_url"`
-//     	SubscribersURL  string  `json:"subscribers_url"`
-//     	SubscriptionURL string  `json:"subscription_url"`
-//     	SvnURL          string  `json:"svn_url"`
-//     	TagsURL         string  `json:"tags_url"`
-//     	TeamsURL        string  `json:"teams_url"`
-//     	TreesURL        string  `json:"trees_url"`
-//     	UpdatedAt       string  `json:"updated_at"`
-//     	URL             string  `json:"url"`
-//     	Watchers        float64 `json:"watchers"`
-//     	WatchersCount   float64 `json:"watchers_count"`
+//     	Private         bool       `json:"private"`
+//     	PullsURL        string     `json:"pulls_url"`
+//     	PushedAt        string     `json:"pushed_at"`
+//     	Size            float64    `json:"size"`
+//     	SshURL          string     `json:"ssh_url"`
+//     	StargazersURL   string     `json:"stargazers_url"`
+//     	StatusesURL     string     `json:"statuses_url"`
+//     	SubscribersURL  string     `json:"subscribers_url"`
+//     	SubscriptionURL string     `json:"subscription_url"`
+//     	SvnURL          string     `json:"svn_url"`
+//     	TagsURL         string     `json:"tags_url"`
+//     	TeamsURL        string     `json:"teams_url"`
+//     	TreesURL        string     `json:"trees_url"`
+//     	UpdatedAt       time.Time  `json:"updated_at"`
+//     	URL             string     `json:"url"`
+//     	Watchers        float64    `json:"watchers"`
+//     	WatchersCount   float64    `json:"watchers_count"`
 // 	}
 package gojson
 
@@ -104,6 +104,7 @@ import (
 	"io"
 	"math"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -491,6 +492,11 @@ func typeForValue(value interface{}, structName string, tags []string, subStruct
 	v := reflect.TypeOf(value).Name()
 	if v == "float64" && convertFloats {
 		v = disambiguateFloatInt(value)
+	} else if v == "string" {
+		matched, err := regexp.MatchString(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?((\+|\-)\d{2}:\d{2}|Z)`, value.(string))
+		if err == nil && matched {
+			v = "time.Time"
+		}
 	}
 	return v
 }


### PR DESCRIPTION
This PR adds support to generate structs with time.Time instead of string when the format matches ISO 8601 / RFC 3339.